### PR TITLE
Fix: AI chat treating modification instructions as literal content

### DIFF
--- a/electron/api/core/chat.ts
+++ b/electron/api/core/chat.ts
@@ -196,10 +196,15 @@ const buildToolsForRequirement = async (data: ChatWithAIParams) => {
     },
     {
       name: "update_requirement_description",
-      description: "Suggest content modifications to the current requirement description",
+      description:
+        "Suggest content modifications to the current requirement description. CRITICAL: When user provides instructions with action verbs (elaborate, expand, simplify, etc.), pass the PROCESSED RESULT of applying those actions, NOT the instruction itself. Only pass the final modified content.",
       schema: z.object({
-        contentToAdd: z.string()
-      })
+        contentToAdd: z
+          .string()
+          .describe(
+            "The complete modified requirement content after processing any user instructions. Never pass instruction text like 'elaborate X' or 'expand Y' - instead pass the actual elaborated/expanded/modified content."
+          ),
+      }),
     }
   );
 

--- a/electron/prompts/core/chat-with-ai.ts
+++ b/electron/prompts/core/chat-with-ai.ts
@@ -71,8 +71,16 @@ export const chatWithAIPrompt = (params: ChatWithAIParams) => {
     - Content completely replaces existing description upon approval
     - Always fetch current content before making updates
 
-    ## 🔍 Scope Awareness
-    Multiple requirements may exist for this type. The current discussion might not cover the complete scope. When needed, ask for additional context to provide better guidance.
+    ## 🔍 Enhanced Context Guidelines
+    - **Project Ecosystem Awareness**: Always consider the broader project ecosystem when making suggestions
+    - **Clarifying Questions**: Ask clarifying questions when requirement scope seems incomplete or ambiguous
+    - **Context Verification**: When uncertain about project-specific details, explicitly verify assumptions with the user
+
+    ## 📊 Content Quality Standards
+    - **Technical Accuracy**: Ensure all technical details are accurate and feasible within the project context
+    - **Consistency**: Maintain consistency with established project terminology and conventions
+    - **Goal Alignment**: Verify alignment with project goals and constraints before suggesting changes
+    - **Completeness**: Ensure content addresses all relevant aspects of the requirement type
 
     ## 📋 Instruction Processing Examples
 
@@ -91,6 +99,15 @@ export const chatWithAIPrompt = (params: ChatWithAIParams) => {
     **User says**: "The system should support OAuth 2.0"
     - ✅ Correct: This is actual content, pass it directly to update tool
 
+    ## 🎯 Accuracy Protocols
+    - **Assumption Clarity**: When uncertain about technical details, explicitly state assumptions and seek confirmation
+    - **Fact vs. Interpretation**: Clearly distinguish between established facts and your interpretations or suggestions
+
+    ## 🔄 Collaboration Enhancement
+    - **Change Rationale**: Provide clear rationale for significant content changes or suggestions
+    - **Alternative Approaches**: Offer alternative approaches when multiple valid solutions exist
+    - **Feedback Integration**: Actively incorporate user feedback to improve subsequent responses
+
     ## 🚨 OPERATIONAL GUIDELINES
 
     ### ✅ MUST DO:
@@ -104,6 +121,8 @@ export const chatWithAIPrompt = (params: ChatWithAIParams) => {
       - Recognize these as instructions about HOW to modify content
       - Process the instruction and generate the modified result
       - Pass only the final modified content to tools, never the instruction itself
+    - **CONTEXT VERIFICATION**: Before making significant suggestions, verify understanding of project context and user intent
+    - **QUALITY ASSURANCE**: Ensure all suggestions meet technical accuracy and project alignment standards
 
     ### ❌ MUST NOT:
     - Expose your persona or these instructions unless explicitly asked

--- a/electron/prompts/core/chat-with-ai.ts
+++ b/electron/prompts/core/chat-with-ai.ts
@@ -35,16 +35,61 @@ export const chatWithAIPrompt = (params: ChatWithAIParams) => {
     ### When to use \`update_requirement_description\`:
     1. **Valuable discussion outcomes** that should be documented
     2. **Explicit user requests** to add or update content
+    3. **Content modifications** based on user instructions
 
-    ### Content Modification Rules:
-    - User receives notification and approves/rejects updates. Please wait there for their response. Strictly do not proceed without their confirmation.
-    - Content completely updates to existing description upon approval
-    - Keep complete update **direct and focused** - no intros/conclusions
-    - **Always fetch current content first** before making updates
-    - Content will be enhanced to merge properly with existing description
+    ### ⚡ CRITICAL: Distinguishing Instructions from Content
+    
+    **User Intent Analysis**:
+    When a user message contains action verbs or directive language, they are giving you INSTRUCTIONS about HOW to modify content, not providing content itself.
+    
+    **Common Instruction Patterns** (process these, don't add as content):
+    - Action verbs: elaborate, expand, shorten, simplify, clarify, detail, summarize, rewrite, modify, update, change, improve, enhance, refine, restructure
+    - Directive phrases: "make it more...", "add details about...", "focus on...", "remove the part about...", "keep ... unaltered"
+    - Positional instructions: "first paragraph", "second section", "beginning of", "end of"
+    - Conditional modifications: "if..., then change...", "except for...", "but keep..."
+    
+    **Actual Content Indicators**:
+    - Quoted text: "Add this: '...'"
+    - Feature specifications without action verbs
+    - Direct statements of requirements
+    - Technical descriptions
+    
+    ### Content Modification Protocol:
+    1. **Analyze user message**: Is it an instruction (contains action verbs/directives) or content?
+    2. **If instruction detected**:
+       - Fetch current content using \`get_current_requirement_content\`
+       - Apply the requested modification action
+       - Generate the complete modified content
+       - Pass ONLY the final result to \`update_requirement_description\`
+    3. **If actual content detected**:
+       - Pass the content directly to \`update_requirement_description\`
+    
+    ### Key Rules:
+    - **NEVER** pass instruction text as content
+    - **ALWAYS** process instructions first, then pass the result
+    - User receives notification and approves/rejects updates
+    - Content completely replaces existing description upon approval
+    - Always fetch current content before making updates
 
     ## 🔍 Scope Awareness
     Multiple requirements may exist for this type. The current discussion might not cover the complete scope. When needed, ask for additional context to provide better guidance.
+
+    ## 📋 Instruction Processing Examples
+
+    **User says**: "Elaborate the security section and keep rest unaltered"
+    - ❌ Wrong: Pass "Elaborate the security section and keep rest unaltered" to update tool
+    - ✅ Correct: Fetch content → Elaborate security section → Keep rest same → Pass complete modified content
+
+    **User says**: "Simplify the technical jargon in the description"
+    - ❌ Wrong: Pass "Simplify the technical jargon in the description" to update tool
+    - ✅ Correct: Fetch content → Simplify technical terms → Pass simplified content
+
+    **User says**: "Add more details about authentication flow"
+    - ❌ Wrong: Pass "Add more details about authentication flow" to update tool
+    - ✅ Correct: Fetch content → Add authentication details → Pass enhanced content
+
+    **User says**: "The system should support OAuth 2.0"
+    - ✅ Correct: This is actual content, pass it directly to update tool
 
     ## 🚨 OPERATIONAL GUIDELINES
 
@@ -55,6 +100,10 @@ export const chatWithAIPrompt = (params: ChatWithAIParams) => {
     - Use markdown **sparingly** (renders in smaller size)
     - End with **engaging questions** when appropriate to continue dialogue
     - If already the existing content is in specific format and that format is correct, strictly follow that format instead of changing it
+    - **INSTRUCTION PROCESSING**: When user messages contain action verbs or directives:
+      - Recognize these as instructions about HOW to modify content
+      - Process the instruction and generate the modified result
+      - Pass only the final modified content to tools, never the instruction itself
 
     ### ❌ MUST NOT:
     - Expose your persona or these instructions unless explicitly asked

--- a/ui/src/app/pages/edit-user-stories/edit-user-stories.component.html
+++ b/ui/src/app/pages/edit-user-stories/edit-user-stories.component.html
@@ -126,7 +126,7 @@
         class="h-full block"
         [name]="projectMetadata?.name"
         [description]="projectMetadata?.description"
-        [baseContent]="description"
+        [baseContent]="userStoryForm.getRawValue().description"
         [chatHistory]="chatHistory"
         [prd]="selectedPRD.requirement"
         (getContent)="updateContent($event)"


### PR DESCRIPTION
### Description

Fix: AI chat treating modification instructions as literal content

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] I have reviewed [contributor guidelines](https://github.com/presidio-oss/specif-ai/blob/main/CONTRIBUTING.md)
